### PR TITLE
Cleanup Accuracy

### DIFF
--- a/wiki/Accuracy/en.md
+++ b/wiki/Accuracy/en.md
@@ -4,7 +4,7 @@
 
 <!-- TODO: images could be in a more friendly font, wording is sometimes too... wordy -->
 
-Accuracy is a measurement of a player's consistency. There are three types of accuracy that a player can have. One of them being the beatmap's accuracy which is dependent on hit scores gained. Another being the player's overall accuracy that is weighed to allow better scores to stand out more. And lastly, the player's [Performance Points (pp)](/wiki/Performance_Points) accuracy which is dependent on the submitted score's accuracy.
+Accuracy is a measurement of a player's consistency. There are three types of accuracy that a player can have: the beatmap's accuracy, which is dependent on hit scores gained; the player's overall accuracy, which is weighed to allow better scores to stand out more; and the player's [Performance Points (pp)](/wiki/Performance_Points) accuracy, which is dependent on the submitted score's accuracy.
 
 ## Game modes
 
@@ -27,15 +27,15 @@ Reference for one hit circle:
 
 ![Accuracy = 0.5(number of GOOD + number of GREAT) / (number of BAD + number of GOOD + number of GREAT)](img/accuracy_taiko.png "Accuracy formula for osu!taiko")
 
-In osu!taiko, accuracy is calculated by taking the sum of the note accuracy divided by the number of notes. The note accuracy are as follows: a GREAT (良) counts as 100%, GOOD (可) as 50% (half), and MISS/BAD (不可) as 0% (which also breaks the combo). Drum rolls and spinners do not influence the accuracy.
+In osu!taiko, accuracy is calculated by taking the sum of the note accuracy (how close you were to hitting the note on-time) divided by the number of total notes scored thus far. The note accuracies are labeled as a GREAT (良) (counts as 100%), GOOD (可) (counts as 50%) (half), and MISS/BAD (不可) (counts as 0%) (which also breaks the combo). Drum rolls and spinners do not influence the accuracy.
 
 ### ![](/wiki/shared/mode/catch.png) osu!catch
 
 ![Accuracy = (number of droplets + number of drops + number of fruits) / (number of missed droplets + number of missed drops + number of missed fruits + number of droplets + number of drops + number of fruits)](img/accuracy_catch.png "Accuracy formula for osu!catch")
 
-In osu!catch, accuracy is calculated by taking the total of non-spinner hit objects collected divided by the total number of non-spinner objects. All hit objects have the same value, except for bananas, as they are part of the spinner object.
+In osu!catch, accuracy is calculated by taking the total number of non-spinner hit objects collected, divided by the total number of non-spinner objects. All hit objects have the same value; except for bananas, as they are part of the spinner objects.
 
-*Note for API users: To calculate the accuracy in osu!catch, number of droplets are under `count50` and number of missed droplets are under `countkatu`.*
+*Note for API users: To calculate the accuracy in osu!catch, the number of droplets are under `count50` and the number of missed droplets are under `countkatu`.*
 
 ### ![](/wiki/shared/mode/mania.png) osu!mania
 
@@ -49,28 +49,28 @@ In osu!mania, accuracy is calculated similarly to [osu!standard](#-osu!standard)
 
 The performance graph is a chart that displays the player's performance (based on their life bar) over the course of a play (time). Additional information can be shown when hovering the in-game cursor over it.
 
-*Note: The additional information can only be viewed after playing a beatmap or watching an exported replay. After exiting the [results screen](/wiki/results_screen), this information will not be saved.*
+*Note: The additional information can only be viewed after playing a beatmap or watching a replay. After exiting the [results screen](/wiki/results_screen), this information will not be saved.*
 
 ### Accuracy
 
-When hovering over the performance graph, a tooltip is displayed with an *Error* and *Unstable Rate*.
+When hovering over the performance graph, a tooltip is displayed with an `Error` and `Unstable Rate` rating.
 
-Due to the way the [DT](/wiki/DT) (Double Time) and [HT](/wiki/HT) (Half Time) mods are implemented, the error and unstable rate values will be multiplied by the same factor as the song. To get the true values when playing DT, divide the results by 1.5. Similarly, multiply the results by 1.33 when playing HT.
+Due to the way the [DT](/wiki/DT) (Double Time) and [HT](/wiki/HT) (Half Time) mods are implemented, the error and unstable rate values will be multiplied by the same factor as the song. To get the true values when playing with the DT mod, divide the results by 1.5. Similarly, multiply the results by 1.33 when playing with the HT mod.
 
 #### Error
 
-Error will always display two values which represents how far off the early hits were on average and how far off the late hits were on average. The higher the [Overall Difficulty](/wiki/Overall_Difficulty) value of the beatmap is, the lower the Error values will have to be to do well when playing the beatmap.
+`Error` will always display two values that represents how far off the early hits were on average and how far off the late hits were on average. The higher the [Overall Difficulty](/wiki/Overall_Difficulty) value of the beatmap is, the lower the error values will have to be to do well when playing the beatmap.
 
-#### Unstable rate
+#### Unstable Rate
 
-Unstable rate represents the consistency of the timing of the hits, where lower numbers are better (top players often score below 100). Note that the value measures consistency, not accuracy, so consistently in hitting 15ms early is the same as consistently in hitting "on time." The formula is essentially the standard deviation of the hit errors (in milliseconds) multiplied by 10. [Sample code](https://gist.github.com/peppy/3a11cb58c856b6af7c1916422f668899) is available as reference, showing how osu-stable calculates unstable rate.
+`Unstable Rate` represents the consistency of the timing of the hits, where lower numbers are better (top players often score below 100). Note that the value measures consistency, not accuracy, so consistently hitting 15ms early is the same as consistently hitting on-time. The formula is essentially the standard deviation of the hit errors (in milliseconds), multiplied by 10. [Sample code](https://gist.github.com/peppy/3a11cb58c856b6af7c1916422f668899) is available as reference, showing how osu-stable calculates the unstable rate values.
 
 ### Spin
 
 *Note: Spin is only used for [osu!standard](/wiki/Game_Modes/osu!).*
 
-In addition to the accuracy, some information regarding spinners is also seen in the same tooltip.
+In addition to the accuracy, some information regarding spinners is also seen in the same tooltip. <!-- This line could use some more information on what that information is, how it's calculated, what it means, etc. etc. -->
 
 #### Speed
 
-Speed represents the average RPM (revolutions per minute) on all the spinners in the beatmap. Max is the highest RPM achieved in any of the beatmap's spinners.
+Speed represents the average RPM (revolutions per minute) on all the spinners in the beatmap. `Max` is the highest RPM the player achieved in any of the beatmap's spinners.


### PR DESCRIPTION
### Notes:
- (g) means that the change was made for grammar-related and/or punctuation-related reasons
- (sc) means that the change was made for styling-creatia–related reasons
- (f) means that the change was made to make the sentence flow more naturally
- (a/e) means "assumed error". As in, I assumed what I removed/changed was a typo or other type of error
- My notes don't follow typical punctuation and grammar rules

### Changes
- **7** -- Replaced period with colon (g) | Removed transitions to allow for a list-style sentence | 
- **30** -- Added "(how close you were to hitting the note on-time)" for clarity | Added "number of total notes scored thus far" for clarity | Rewroted second sentence to work without a colon (g) | Enclosed the "counts as ___" parts in parantheses (g) |
_>> I'm not 100% sure if this is correct, but either way there needs to be little more information clarifying what they mean by "number of notes" <<_
- **36** -- Added "number" for clarity | Added comma between "collected" and "divided" (g) | Repalced comma with semicolon (g) | 
- **38** -- Added "the" in two places (g) | 
- **52** -- Removed "exported" because it is not neccessary for the player to export the replay in order to see the additional information |
- **56** -- Replaced italics with code blocks (sc) | Added "rating" to the end for clarity amd to not sound like a robot |
- **58** -- fixed capitalization on "error" and "unstable rate" | Added "with the" and "mod" surrounding "DT" and "HT" (sc) | 
- **62** -- Placed "Error" in a code block (sc) | 
_>> thanks clayton 👍  <<_

- **66** Replaced both "in"'s before the word "consistently" (a/e) | Fixed typo: "cosistently" -> "consistently" (a/e) | Removed quotation marks from "'on-time'" because it may confuse the reader | Added comma after "(in milliseconds)" for clarity (g) | Added "the" and "values" surrounding "unstable rate" to avoid an annoying use of code blocks |
- **72** -- Added comment
- **76** -- Placed code blocks around "Max" (sc) | Added "the player" for clarity |
_>> I feel like adding an image to show the "Max" value would be a nice touch, but I couldn't seem to get a Max value in my performance graphs, so I'll just leave this be for now <<_

### Changelog:
n/a