### PR TITLE
Cleanup ppv1

### DIFF
--- a/wiki/Performance_Points/ppv1/en.md
+++ b/wiki/Performance_Points/ppv1/en.md
@@ -2,21 +2,21 @@
 
 # ppv1
 
-The **first performance score** (abbreviated as **ppv1**) is an ancient ranking system for players globally and nationally of all modes from osu!. It replaced the old system of *ranking by total score* and was abandoned for the benefit of [ppv2](..).
+The first performance score (abbreviated as **ppv1**) is an ancient ranking system for players globally across all modes from osu!. It replaced the old system of *ranking by total score* and was abandoned due to the implementation of [ppv2](..).
 
 ## History
 
-ppv1 was launched in April 2012 and initially mentioned in the players profiles under the name ``???`` during a test phase. Then finally renamed to **pp** (performance points) on 17. April 2012. This system existed with the previous ranking system (by total score) and eventually became the unique system in place on 24. July 2012 during the release of the version [20120722-24](https://osu.ppy.sh/community/forums/posts/1687719 "20120722-24") of the osu! client.
+ppv1 was launched in April 2012 and initially mentioned in players' profiles under the name ``???`` during a test phase. After finally being renamed to **pp** (performance points) on April 17, 2012. This system existed with the previous ranking system (*ranking by total score*) and eventually became the unique system in-place on July 24, 2012 during the release of version [20120722-24](https://osu.ppy.sh/community/forums/posts/1687719 "20120722-24") of the osu! client.
 
 
-This system was initially updated at regular intervals, usually every 24 hours, to finally run in real-time on 16. August 2012.
+This system was initially updated at regular intervals (usually every 24 hours) until finally being run in real-time on August 16, 2012.
 
-ppv1 was abandoned and replaced by **ppv2** on 27 January 2014.
+ppv1 was abandoned and replaced by **ppv2** on January 27, 2014.
 The reasons behind that change were the criticism of the players:
 
-* Missing opacity of the algorithm
-* Promotion of ``Hard`` difficulties with mods
-* Low worth of insane difficulties
+- Missing opacity of the algorithm
+- Promotion of ``Hard`` difficulties with mods
+- Low worth of insane difficulties
 
 It also allowed peppy to seperate the job of maintaining and updating the filing system to and thus ease its workload.
 
@@ -24,23 +24,22 @@ It also allowed peppy to seperate the job of maintaining and updating the filing
 
 The calculations involved are not publicly known, however some indications on the inner workings of the system were disclosed:
 
-- ppv1 highlights the skill and can not be farmed.
-- The score is evaluated in relation to the difficulty of the map, based on statistics that were not available to the public.
-- The number of points obtainable naturally decreases with time (thus, inactive players may loose up to half of his points within a year).
-- No penalties for bad scores, only rewards for good scores.
-- All *ranked* and *approved* maps are taken into account in the calculations.
-- The accuracy is taken into account.
+- ppv1 highlights the skill and cannot be farmed.
+- The score is evaluated in relation to the difficulty of the map; based on statistics that were not available to the public.
+- The number of points obtainable naturally decreases with time (thus, inactive players may lose up to half of their points within a year).
+- No penalties for bad scores; only rewards for good scores.
+- All *Ranked* and *Approved* maps are taken into account in the calculations.
+- The player's accuracy is taken into account.
 - The multipliers of mods are different from those announced in the game.
-- Mode specific difficulties are favored.
+- Mode-specific difficulties are favored.
 - If a score is not placed in the top 500 of a map, it will not count.
 
 ## Climbing the rankings
 
-The ranking is mainly related to the performance on individual maps, resulting in players to only focussing and mastering single difficulties.
+The ranking is mainly related to the performance on individual maps, leading many players to only focus on mastering single difficulties. ppv1 encouraged a common theme of practices among players: <!-- the list below is totally vague -->
 
-- Playing better and scoring better grades on the beatmaps.
-- Making sure to get some very good scores rather than thousands of mediocre scores.
-- Improving the accuracy. Even a small percent can make the difference.
+- Playing better and scoring better grades on the beatmaps. 
+- Improving the accuracy; even a small percent can make the difference.
 - Getting a rank on the most popular maps, where it is harder to get a place.
 - Playing difficult maps.
 - Improving old scores.


### PR DESCRIPTION
### Notes:
- (g) means that the change was made for grammar-related and/or punctuation-related reasons
- (sc) means that the change was made for styling-creatia–related reasons
- (f) means that the change was made to make the sentence flow more naturally
- (a/e) means "assumed error". As in, I assumed what I removed/changed was a typo or other type of error
- My notes don't follow typical punctuation and grammar rules

### Changes:
- **5** -- Removed bold from "first performance score" (misuse of emphasis) | Removed "and nationally" (redundant) | Replaced "of" with "across" (g) | Replaced "for the benefit of" with "due to the implementation of" (f) | 
- **9** -- Removed "the" from "the players" and fixed punctuation accordingly (g) | Added "After" and "being" (f) | Fixed date "April 17, 2012" (sc) | Added "ranking" to "(by total score)" and italicized (a/e) | Added hyphen for "in place" (g) | Fixed date "July 24, 2012" (sc) | Removed "the" from "of the version" (a/e) | 
- **12** -- Replaced commas with parantheses to look nicer and to place less emphasis | Replaced "to" with "until" and added "being" (g) | Fixed date "August 16, 2012" (sc) | 
- **14** -- Fixed date "January 27, 2012" (sc) | 
- **17, 18, 19** -- Replaced asterisk with hyphen (sc) | 
- **21** -- _>> the ambiguity of "its" makes this line difficult to correct <<_
- **27** -- Removed space between "can" and "not" (g) |
- **28** -- Replaced comma with semicolon (g) |
- **29** -- Removed additional "o" from "loose" (a/e) | Replaced "his" with "their" (sc) |
- **30** -- Replaced comma with semicolon (g) |
- **31** -- Capitalized "ranked" and "approved"
- **32** -- Added "player's" for clarity |
- **34** -- Added hyphen between "mode" and "specific" (g) |
- **39** Reworded second half of sentence (f) (g) (a/e) |
- **39** -- Added "ppv1 encouraged a common theme of practices among players:" to lead-in to the sentence (a/e) (g) |
- **41** -- Removed "the" (a/e) |
- **Edit** -- Removed line 42 because I could not find out what in the world "surthoe" was (i assume the line was just a joke) |
- **42 (used to be 43)** -- Replaced period with semicolon (g) |

### Changelog:
n/a